### PR TITLE
Fix typo in AppStrap.spec.js

### DIFF
--- a/src/Appstrap.spec.js
+++ b/src/Appstrap.spec.js
@@ -1,4 +1,4 @@
-import Endpoints from './Endpoints'
+import Endpoints from './endpoints'
 import AppServer from './AppServer'
 import Config from './config/loader'
 import Presets from './presets'


### PR DESCRIPTION
./Endpoints doesn't exist and causes the test to fail. I fixed it boo :stuck_out_tongue: 