### PR TITLE
Fix config preset folder path

### DIFF
--- a/src/config/generator.js
+++ b/src/config/generator.js
@@ -58,7 +58,7 @@ class ConfigGenerator {
   static async writeConfigFile (configContents) {
     const filePath = path.resolve(process.cwd(), './.appstrap/config.js')
     await fs.ensureFile(filePath)
-    await fs.ensureDir(path.resolve(process.cwd(), './.appstrap/config/presets'))
+    await fs.ensureDir(path.resolve(process.cwd(), './.appstrap/presets'))
     await fs.writeFile(path.resolve(process.cwd(), './.appstrap/config.js'), configContents)
   }
 


### PR DESCRIPTION
was creating preset folder underneath /config parent directory.  don't want that.