### PR TITLE
bugfix: use path.sep in building of default configFilePath to get correct behaviour on windows

### DIFF
--- a/src/config/loader.js
+++ b/src/config/loader.js
@@ -9,7 +9,7 @@ import Presets from '../presets'
 export class Loader {
   constructor () {
     this.configFileData = {bundle: {}, assets: [], endpoints: []}
-    this.configFilePath = '.appstrap/config.js'
+    this.configFilePath = '.appstrap' + path.sep + 'config.js'
     this.reload = this.reload.bind(this)
   }
 


### PR DESCRIPTION
This PR removes the default forward slash and replaces it with path.sep to get the OS's default separator also in building of the default configFilePath. 

Otherwise on Windows it tries to split on a backslash where there is none present since it is hard coded to a forward slash.