### PR TITLE
Add more npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "dev:core": "webpack --config webpack/core.webpack.config.js --mode development --watch --progress --colors",
     "init": "npm run deploy && node dist/cli.js init",
     "start": "node dist/cli.js start",
-    "generate": "node dist/cli.js init",
     "lint": "standard",
     "test": "jest",
     "test-config": "node dist/cli.js start -c ./_test/_testConfig/config.js --preserve false"

--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
     "deploy:core": "webpack --config webpack/core.webpack.config.js --mode production",
     "dev:ui": "webpack --config webpack/interface.webpack.config.js --mode development --watch --progress --colors",
     "dev:core": "webpack --config webpack/core.webpack.config.js --mode development --watch --progress --colors",
+    "init": "npm run deploy && node dist/cli.js init",
+    "start": "node dist/cli.js start",
+    "generate": "node dist/cli.js init",
     "lint": "standard",
     "test": "jest",
-    "test-config-generate": "node dist/cli.js init",
     "test-config": "node dist/cli.js start -c ./_test/_testConfig/config.js --preserve false"
   },
   "dependencies": {


### PR DESCRIPTION
Hey,

this PR adds more scripts to package.json to be used from CLI via `npm run SCRIPTNAME`. I found these to be missing and totally useful.

People can use `npm run init` after initial install of appstrap so the thing gets built and a config file can be generated. 

`npm run start` would later be used to start appstrap when developing the actuall project rather than the appstrap tool now. 

`npm run generate` can be used to re-/generate a config file from CLI. 

What do you think?