### PR TITLE
always add scroll-bar to UI to avoid jumping interface

### DIFF
--- a/src/management-interface/src/App.js
+++ b/src/management-interface/src/App.js
@@ -14,8 +14,7 @@ const PageContainer = glamorous.section({
   background: '#EFF3F6',
   display: 'flex',
   alignItems: 'center',
-  justifyContent: 'center',
-  overflowY: 'scroll'
+  justifyContent: 'center'
 })
 const AppContainer = glamorous.div({
   padding: '1rem',

--- a/src/management-interface/src/App.js
+++ b/src/management-interface/src/App.js
@@ -14,7 +14,8 @@ const PageContainer = glamorous.section({
   background: '#EFF3F6',
   display: 'flex',
   alignItems: 'center',
-  justifyContent: 'center'
+  justifyContent: 'center',
+  overflowY: 'scroll'
 })
 const AppContainer = glamorous.div({
   padding: '1rem',

--- a/src/management-interface/src/Endpoints/endpointsStyles.js
+++ b/src/management-interface/src/Endpoints/endpointsStyles.js
@@ -5,7 +5,7 @@ import { tabsTotalHeight } from '../Tabs/tabStyles'
 
 export const EndpointsContainer = glamorous.section({
   display: 'flex',
-  height: `calc(100vh - ${headerTotalHeight + tabsTotalHeight}px)`,
+  height: `calc(100vh - ${headerTotalHeight + tabsTotalHeight}px - 2rem)`,
   width: '100%',
   border: `1px solid ${colors.borderColor}`,
   ' aside': {


### PR DESCRIPTION
When switching between "Preset Configurations" and "Endpoints" in the management interface the whole container jumps to the left (maybe only on windows) as the scroll bar is added to the browser window when content overflows screen height.

![scroll-jump](https://user-images.githubusercontent.com/6306291/40888308-af1c7f36-6755-11e8-97e6-633336f4a600.gif)


This PR fixes this issue by always adding the scroll bar by default even when the content doesn't overflow the height. 

