### PR TITLE
Fix bug with port selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,13 +23,15 @@
     "chokidar": "^2.0.3",
     "commander": "^2.14.1",
     "decache": "^4.4.0",
+    "detect-port": "^1.2.3",
     "express": "^4.15.3",
     "fs-extra": "^5.0.0",
     "no-cache-loader": "^1.0.0",
     "pre-commit": "^1.2.2",
     "prettier": "^1.12.1",
     "require-all": "^2.2.0",
-    "sleep-promise": "2.0.0"
+    "sleep-promise": "2.0.0",
+    "vhost": "^3.0.2"
   },
   "devDependencies": {
     "@storybook/react": "^4.0.0-alpha.4",
@@ -41,7 +43,6 @@
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
-    "detect-port": "^1.2.3",
     "glamor": "^2.20.40",
     "glamorous": "^4.13.0",
     "isomorphic-fetch": "^2.2.1",
@@ -61,7 +62,6 @@
     "sinon": "^5.0.10",
     "standard": "^11.0.1",
     "supertest": "^3.0.0",
-    "vhost": "^3.0.2",
     "webpack": "^4.10.2",
     "webpack-cli": "^2.1.4",
     "webpack-node-externals": "^1.7.2"

--- a/src/Appstrap.js
+++ b/src/Appstrap.js
@@ -21,7 +21,6 @@ export class Appstrap {
     // Intentionally wrapped in function to propagate changes when configs are reloaded
     this.middleware = (req, res, next) => this.server._app(req, res, next)
 
-    this.port = this.server.port
     this.start = this.server.start
     this.stop = this.server.stop
     this.setModifier = this.config.endpoints.setModifier
@@ -36,10 +35,12 @@ export class Appstrap {
     }
   }
 
+  get port () { return this.server.port }
+
   updateModules (preserve) {
     try {
       this.config.update()
-      if (this.invokedFromCLI) {
+      if (this.invokedFromCLI && this.config.fileData.initialState) {
         this.presets.update()
       }
       if (preserve !== true) {

--- a/src/Server.js
+++ b/src/Server.js
@@ -37,7 +37,6 @@ export class Server {
 
     this.httpServer = http.createServer(this._app)
     this.httpServer.listenAsync = util.promisify(this.httpServer.listen)
-    this.httpServer.closeAsync = util.promisify(this.httpServer.close)
   }
 
   reloadEndpoints ({config}) { return this.loadEndpoints({config}) }
@@ -100,9 +99,9 @@ export class Server {
   }
 
   async start ({port = this.port} = {}) {
-    this.port = await detectPort(port)
+    const checkedPort = await detectPort(port)
+    this.port = checkedPort
     await this.httpServer.listenAsync(this.port)
-
     /*
      If the server was invoked from CLI, we want to show a confirmation message when the server
       is started.  We will also indicate the management interface port to make people more aware
@@ -122,10 +121,12 @@ export class Server {
     }
   }
 
-  async stop () {
-    if (this.httpServer.address()) {
-      await this.httpServer.closeAsync()
-    }
+  stop () {
+    return new Promise((resolve) => {
+      this.httpServer.listening
+        ? this.httpServer.close(() => resolve())
+        : resolve()
+    })
   }
 }
 

--- a/src/Server.spec.js
+++ b/src/Server.spec.js
@@ -76,11 +76,6 @@ describe('Server', () => {
       expect(server.httpServer.listenAsync).toBeDefined()
       expect(server.httpServer.listenAsync.toString()).toContain('return promise')
     })
-    test('created http server has closeAsync method that returns a promise', () => {
-      const server = new Server({config})
-      expect(server.httpServer.closeAsync).toBeDefined()
-      expect(server.httpServer.closeAsync.toString()).toContain('return promise')
-    })
   })
 
   describe('loadEndpoints', () => {


### PR DESCRIPTION
Port selection was assigned once and then never updated on appstrap level even when server port changed.  Switched to getter to resolve this.

Also fixed issue where state is set to undefined when attempting to hot reload where preserve is false and no initial state is set

Also moved detect-port and vhost to dependencies where some installs did not include them by default.